### PR TITLE
chore(ci): bump actions/checkout from v2 to v7

### DIFF
--- a/.github/workflows/publish_pypi_release.yml
+++ b/.github/workflows/publish_pypi_release.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: setup python
         uses: actions/setup-python@v2


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from `@v2` to `@v7` (current stable release).
- `v2` is well past EOL; `v7` is the current major version.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>